### PR TITLE
feat(auth): centralize token parsing

### DIFF
--- a/src/auth/bearer.test.ts
+++ b/src/auth/bearer.test.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 import request from 'supertest';
 import { __setConfigForTests } from '../config/config';
 import app from '../server';
+import * as tokenMod from './token';
 
 describe('bearer middleware', () => {
   beforeAll(() => {
@@ -55,5 +56,31 @@ describe('bearer middleware', () => {
       .get('/api/file')
       .query({ path: 'x', token: 'badtoken' });
     expect(res.status).toBe(401);
+  });
+
+  it('file route: accepts valid token in query', async () => {
+    const token = jwt.sign({ username: 'a', role: 'user' }, 'secret', {
+      expiresIn: 60,
+    });
+    const res = await request(app).get('/api/file').query({ path: 'x', token });
+    expect([200, 400, 500]).toContain(res.status);
+  });
+
+  it('handles parseToken throwing', async () => {
+    const tokenStr = jwt.sign({ username: 'a', role: 'user' }, 'secret', {
+      expiresIn: 60,
+    });
+    const spy = jest.spyOn(tokenMod, 'parseToken').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const resTree = await request(app)
+      .get('/api/tree')
+      .set('Authorization', `Bearer ${tokenStr}`);
+    expect(resTree.status).toBe(401);
+    const resFile = await request(app)
+      .get('/api/file')
+      .query({ path: 'x', token: tokenStr });
+    expect(resFile.status).toBe(401);
+    spy.mockRestore();
   });
 });

--- a/src/auth/token.test.ts
+++ b/src/auth/token.test.ts
@@ -1,0 +1,52 @@
+import jwt from 'jsonwebtoken';
+import { parseToken } from './token';
+import { __setConfigForTests } from '../config/config';
+import type { Request } from 'express';
+
+describe('parseToken', () => {
+  beforeAll(() => {
+    __setConfigForTests({
+      root: process.cwd(),
+      users: [],
+      auth: { jwtSecret: 'secret', tokenTtlMinutes: 1 },
+    } as any);
+  });
+  afterAll(() => __setConfigForTests(null));
+
+  function makeReq(
+    headerValue?: string,
+    query: Record<string, unknown> = {},
+  ): Request {
+    return {
+      header: (name: string) =>
+        name === 'Authorization' ? headerValue : undefined,
+      query,
+    } as unknown as Request;
+  }
+
+  it('returns user for valid header token', () => {
+    const token = jwt.sign({ username: 'a', role: 'user' }, 'secret', {
+      expiresIn: 60,
+    });
+    const req = makeReq(`Bearer ${token}`);
+    expect(parseToken(req)).toEqual({ username: 'a', role: 'user' });
+  });
+
+  it('returns null for invalid token', () => {
+    const req = makeReq('Bearer notatoken');
+    expect(parseToken(req)).toBeNull();
+  });
+
+  it('returns user for token in query', () => {
+    const token = jwt.sign({ username: 'a', role: 'admin' }, 'secret', {
+      expiresIn: 60,
+    });
+    const req = makeReq(undefined, { token });
+    expect(parseToken(req)).toEqual({ username: 'a', role: 'admin' });
+  });
+
+  it('returns null when token missing', () => {
+    const req = makeReq();
+    expect(parseToken(req)).toBeNull();
+  });
+});

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -1,0 +1,29 @@
+import { Request } from 'express';
+import jwt from 'jsonwebtoken';
+import { loadConfig } from '../config/config';
+import type { JwtUser } from '../types/index.d.ts';
+
+export function parseToken(req: Request): JwtUser | null {
+  const auth = req.header('Authorization');
+  const queryToken =
+    typeof req.query.token === 'string'
+      ? (req.query.token as string)
+      : undefined;
+
+  let token: string | undefined;
+  if (auth && auth.startsWith('Bearer '))
+    token = auth.slice('Bearer '.length).trim();
+  else if (queryToken) token = queryToken;
+  if (!token) return null;
+
+  try {
+    const cfg = loadConfig();
+    const payload = jwt.verify(token, cfg.auth.jwtSecret) as jwt.JwtPayload;
+    return {
+      username: String(payload.username),
+      role: payload.role as 'admin' | 'user',
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `parseToken` helper to decode JWT from request headers or query
- simplify bearer middlewares to leverage new helper
- expand tests for token parsing and middleware edge cases

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68be8765fe88832391dd1641fcf17105