### PR TITLE
feat(fs): validate symlinks

### DIFF
--- a/src/fs/fileOps.ts
+++ b/src/fs/fileOps.ts
@@ -15,7 +15,7 @@ type HttpError = Error & { status?: number };
 export async function list(
   relDir: string,
 ): Promise<{ cwd: string; parent: string | null; items: TreeItem[] }> {
-  const dirAbs = resolveSafePath(relDir);
+  const dirAbs = await resolveSafePath(relDir);
   const stat = await fs.promises.stat(dirAbs);
   if (!stat.isDirectory()) {
     const err: HttpError = new Error('Not a directory');
@@ -66,7 +66,7 @@ export async function list(
 export async function getFileMeta(
   relFile: string,
 ): Promise<{ abs: string; size: number; mimeType: string; filename: string }> {
-  const abs = resolveSafePath(relFile);
+  const abs = await resolveSafePath(relFile);
   const st = await fs.promises.stat(abs);
   if (st.isDirectory()) {
     const err: HttpError = new Error('Is a directory');
@@ -80,14 +80,14 @@ export async function getFileMeta(
 }
 
 export async function move(fromRel: string, toRel: string): Promise<void> {
-  const fromAbs = resolveSafePath(fromRel);
-  const toAbs = resolveSafePath(toRel);
+  const fromAbs = await resolveSafePath(fromRel);
+  const toAbs = await resolveSafePath(toRel);
   await fs.promises.mkdir(path.dirname(toAbs), { recursive: true });
   await fs.promises.rename(fromAbs, toAbs);
 }
 
 export async function remove(relPath: string): Promise<void> {
-  const abs = resolveSafePath(relPath);
+  const abs = await resolveSafePath(relPath);
   await fs.promises.rm(abs, { recursive: true, force: true });
 }
 /* istanbul ignore file */

--- a/src/fs/pathSafe.test.ts
+++ b/src/fs/pathSafe.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import { __setConfigForTests } from '../config/config';
 import { resolveSafePath, toRelative } from './pathSafe';
@@ -5,29 +6,45 @@ import { resolveSafePath, toRelative } from './pathSafe';
 describe('pathSafe', () => {
   const root = path.resolve(process.cwd(), 'tmp-root');
   beforeAll(() => {
+    fs.mkdirSync(root, { recursive: true });
     __setConfigForTests({
       root,
       users: [],
       auth: { jwtSecret: 's', tokenTtlMinutes: 10 },
     } as any);
   });
-  afterAll(() => __setConfigForTests(null));
+  afterAll(() => {
+    __setConfigForTests(null);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 
-  it('resolves inside root', () => {
-    const p = resolveSafePath('a/b');
+  it('resolves inside root', async () => {
+    const p = await resolveSafePath('a/b');
     expect(p.startsWith(root)).toBe(true);
   });
 
-  it('blocks traversal', () => {
-    expect(() => resolveSafePath('../etc/passwd')).toThrow();
+  it('blocks traversal', async () => {
+    await expect(resolveSafePath('../etc/passwd')).rejects.toThrow();
   });
 
   it('toRelative returns . for root', () => {
     expect(toRelative(root)).toBe('.');
   });
 
-  it('resolveSafePath of dot equals root', () => {
-    const p = resolveSafePath('.');
+  it('resolveSafePath of dot equals root', async () => {
+    const p = await resolveSafePath('.');
     expect(p).toBe(root);
+  });
+
+  it('rejects symlink outside root', async () => {
+    const outside = path.resolve(process.cwd(), 'tmp-out');
+    fs.mkdirSync(outside, { recursive: true });
+    const link = path.join(root, 'link-out');
+    fs.symlinkSync(outside, link);
+    await expect(resolveSafePath('link-out')).rejects.toMatchObject({
+      status: 403,
+    });
+    fs.rmSync(link, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
   });
 });

--- a/src/fs/pathSafe.ts
+++ b/src/fs/pathSafe.ts
@@ -1,7 +1,8 @@
+import fs from 'fs';
 import path from 'path';
 import { loadConfig } from '../config/config';
 
-export function resolveSafePath(rel: string): string {
+export async function resolveSafePath(rel: string): Promise<string> {
   const cfg = loadConfig();
   const root = path.resolve(cfg.root);
   const requested = rel ?? '';
@@ -11,9 +12,15 @@ export function resolveSafePath(rel: string): string {
     throw Object.assign(new Error('Forbidden path'), { status: 403 });
   }
   const abs = path.resolve(root, normRel);
+  let real: string;
+  try {
+    real = await fs.promises.realpath(abs);
+  } catch {
+    real = abs;
+  }
   /* istanbul ignore next */ if (
-    abs !== root &&
-    !abs.startsWith(root + path.sep)
+    real !== root &&
+    !real.startsWith(root + path.sep)
   ) {
     throw Object.assign(new Error('Forbidden path'), { status: 403 });
   }


### PR DESCRIPTION
## Summary
- harden resolveSafePath by resolving realpath and blocking symlinks outside root
- cover symlink escapes with new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3cf27cd9483239a0a3dffcb00c0b4