### PR TITLE
Ignore invalid drag move alerts

### DIFF
--- a/public/app.ts
+++ b/public/app.ts
@@ -197,7 +197,6 @@ function render(tree: TreeResponse): void {
         if (!from) return;
         const destDir = `${tree.cwd}/${it.name}`;
         if (from === destDir || destDir.startsWith(from + '/')) {
-          alert('Invalid move');
           return;
         }
         try {


### PR DESCRIPTION
## Summary
- suppress `Invalid move` alert in file drag-drop handler and silently ignore invalid targets

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c6dc0ded908323b7b3becfa561e78b